### PR TITLE
apollo client ssrMode doesn't work

### DIFF
--- a/@app/client/src/withApollo.js
+++ b/@app/client/src/withApollo.js
@@ -61,7 +61,7 @@ export function createApolloClient(ssr = false, cache, apolloLink, csrfToken) {
       ssr
         ? {
           // Set this on the server to optimize queries when SSR
-          ssrMode: true,
+          // ssrMode: true,
         }
         : {
           // This will temporary disable query force-fetching


### PR DESCRIPTION
Have to figure out is this even needed. Original starter doesn't set this.

Problem rises when we query from cache, it doesn't resolve all the promises and @vue/server-renderer waits forever.